### PR TITLE
fix: show.blade.php broken localization text on heading

### DIFF
--- a/src/stubs/views/show.stub
+++ b/src/stubs/views/show.stub
@@ -1,7 +1,7 @@
 @extends('{{layout}}')
 
 @section('template_title')
-    {{ ${{modelNameLowerCase}}->name ?? "{{ __('Show') {{modelTitle}}" }}
+    {{ ${{modelNameLowerCase}}->name ?? __('Show') . " " . __('{{modelTitle}}') }}
 @endsection
 
 @section('content')


### PR DESCRIPTION
On the `show.blade.php` file, the layout breaks like the image below. 

![image](https://user-images.githubusercontent.com/29670783/227885141-4b7680e2-2835-4959-a1e8-01b4f18b4e8b.png)

I'm opening pull request to fix the issue.