### PR TITLE
Handling tables with prefix befor table name

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,14 @@ Route name in plural slug case.
 php artisan make:crud {table_name} --route={route_name}
 ```
 
+- Removing prefix from 
+
+```
+php artisan make:crud {table_name} --prefix={prefix_to_remove}
+```
+**Example**
+In a table named **az_banks** the prefix would be **az_**, if you added this option the model name will be **Bank** and the controller name will be **BankController**
+
 ## Example
 
 *Model*

--- a/src/Commands/CrudGenerator.php
+++ b/src/Commands/CrudGenerator.php
@@ -18,7 +18,10 @@ class CrudGenerator extends GeneratorCommand
      */
     protected $signature = 'make:crud
                             {name : Table name}
-                            {--route= : Custom route name}';
+                            {--route= : Custom route name}
+                            {--prefix= : Custom route name}
+                            
+                            ';
 
     /**
      * The console command description.
@@ -49,6 +52,7 @@ class CrudGenerator extends GeneratorCommand
 
         // Build the class name from table name
         $this->name = $this->_buildClassName();
+        $this->cleanName = $this->name;
 
         // Generate the crud
         $this->buildOptions()
@@ -70,7 +74,7 @@ class CrudGenerator extends GeneratorCommand
      */
     protected function buildController()
     {
-        $controllerPath = $this->_getControllerPath($this->name);
+        $controllerPath = $this->_getControllerPath($this->cleanName);
 
         if ($this->files->exists($controllerPath) && $this->ask('Already exist Controller. Do you want overwrite (y/n)?', 'y') == 'n') {
             return $this;
@@ -81,7 +85,9 @@ class CrudGenerator extends GeneratorCommand
         $replace = $this->buildReplacements();
 
         $controllerTemplate = str_replace(
-            array_keys($replace), array_values($replace), $this->getStub('Controller')
+            array_keys($replace),
+            array_values($replace),
+            $this->getStub('Controller')
         );
 
         $this->write($controllerPath, $controllerTemplate);
@@ -96,7 +102,7 @@ class CrudGenerator extends GeneratorCommand
      */
     protected function buildModel()
     {
-        $modelPath = $this->_getModelPath($this->name);
+        $modelPath = $this->_getModelPath($this->cleanName);
 
         if ($this->files->exists($modelPath) && $this->ask('Already exist Model. Do you want overwrite (y/n)?', 'y') == 'n') {
             return $this;
@@ -108,7 +114,9 @@ class CrudGenerator extends GeneratorCommand
         $replace = array_merge($this->buildReplacements(), $this->modelReplacements());
 
         $modelTemplate = str_replace(
-            array_keys($replace), array_values($replace), $this->getStub('Model')
+            array_keys($replace),
+            array_values($replace),
+            $this->getStub('Model')
         );
 
         $this->write($modelPath, $modelTemplate);
@@ -151,7 +159,9 @@ class CrudGenerator extends GeneratorCommand
 
         foreach (['index', 'create', 'edit', 'form', 'show'] as $view) {
             $viewTemplate = str_replace(
-                array_keys($replace), array_values($replace), $this->getStub("views/{$view}")
+                array_keys($replace),
+                array_values($replace),
+                $this->getStub("views/{$view}")
             );
 
             $this->write($this->_getViewPath($view), $viewTemplate);

--- a/src/Commands/GeneratorCommand.php
+++ b/src/Commands/GeneratorCommand.php
@@ -53,6 +53,13 @@ abstract class GeneratorCommand extends Command
     protected $name = null;
 
     /**
+     * Formatted Class claan name without prefix from Table.
+     *
+     * @var string
+     */
+    protected $cleaNname = null;
+
+    /**
      * Store the DB table columns.
      *
      * @var array
@@ -245,7 +252,7 @@ abstract class GeneratorCommand extends Command
      */
     protected function _getViewPath($view)
     {
-        $name = Str::kebab($this->name);
+        $name = Str::kebab($this->cleanName);
 
         return $this->makeDirectory(resource_path("/views/{$name}/{$view}.blade.php"));
     }
@@ -257,17 +264,18 @@ abstract class GeneratorCommand extends Command
      */
     protected function buildReplacements()
     {
+
         return [
             '{{layout}}' => $this->layout,
-            '{{modelName}}' => $this->name,
-            '{{modelTitle}}' => Str::title(Str::snake($this->name, ' ')),
+            '{{modelName}}' => $this->cleanName,
+            '{{modelTitle}}' => Str::title(Str::snake($this->cleanName, ' ')),
             '{{modelNamespace}}' => $this->modelNamespace,
             '{{controllerNamespace}}' => $this->controllerNamespace,
-            '{{modelNamePluralLowerCase}}' => Str::camel(Str::plural($this->name)),
-            '{{modelNamePluralUpperCase}}' => ucfirst(Str::plural($this->name)),
-            '{{modelNameLowerCase}}' => Str::camel($this->name),
-            '{{modelRoute}}' => $this->options['route'] ?? Str::kebab(Str::plural($this->name)),
-            '{{modelView}}' => Str::kebab($this->name),
+            '{{modelNamePluralLowerCase}}' => Str::camel(Str::plural($this->cleanName)),
+            '{{modelNamePluralUpperCase}}' => ucfirst(Str::plural($this->cleanName)),
+            '{{modelNameLowerCase}}' => Str::camel($this->cleanName),
+            '{{modelRoute}}' => $this->options['route'] ?? Str::kebab(Str::plural($this->cleanName)),
+            '{{modelView}}' => Str::kebab($this->cleanName),
         ];
     }
 
@@ -290,7 +298,9 @@ abstract class GeneratorCommand extends Command
         ]);
 
         return str_replace(
-            array_keys($replace), array_values($replace), $this->getStub("views/{$type}")
+            array_keys($replace),
+            array_values($replace),
+            $this->getStub("views/{$type}")
         );
     }
 
@@ -441,6 +451,7 @@ abstract class GeneratorCommand extends Command
             '{{properties}}' => $properties,
             '{{softDeletesNamespace}}' => $softDeletesNamespace,
             '{{softDeletes}}' => $softDeletes,
+            '{{tableName}}' => $this->table,
         ];
     }
 
@@ -462,9 +473,18 @@ abstract class GeneratorCommand extends Command
     protected function buildOptions()
     {
         $route = $this->option('route');
+        $prefix = $this->option('prefix');
 
         if (!empty($route)) {
             $this->options['route'] = $route;
+        }
+
+        if (!empty($prefix)) {
+            // $this->table = str_replace($prefix, "", $this->taxble);
+            $cName = str_replace($prefix, "", $this->table);
+            $this->cleanName = Str::studly(Str::singular($cName));
+
+            $this->options['prefix'] = $prefix;
         }
 
         return $this;
@@ -491,4 +511,6 @@ abstract class GeneratorCommand extends Command
     {
         return Schema::hasTable($this->table);
     }
+
+    
 }

--- a/src/stubs/Model.stub
+++ b/src/stubs/Model.stub
@@ -12,6 +12,8 @@ use Illuminate\Database\Eloquent\Model;
  */
 class {{modelName}} extends Model
 {
+    protected $table = '{{tableName}}';
+    
     {{softDeletes}}
     static $rules = [{{rules}}
     ];


### PR DESCRIPTION
In a table named az_banks the prefix would be az_, if you added this option the model name will be Bank and the controller name will be BankController

Ex : 
```
php artisan make:crud {table_name} --prefix={prefix_to_remove}
```