### PR TITLE
fix(modelgenerator): fixed foreign table extraction in getBelongsTo method.

### DIFF
--- a/src/ModelGenerator.php
+++ b/src/ModelGenerator.php
@@ -111,7 +111,7 @@ class ModelGenerator
                 continue;
             }
 
-            $foreignTable = $this->extractTableName($table);
+            $foreignTable = $this->extractTableName($relation['foreign_table']);
 
             $eloquent[] = [
                 'name' => 'belongsTo',


### PR DESCRIPTION
Fix #58, use the `foreign_table` key of the `$relation` object instead of not declared variable `$table`.