### PR TITLE
Fix: Livewire stubs not found on Linux (case sensitivity)

### DIFF
--- a/src/stubs/livewire/create.stub
+++ b/src/stubs/livewire/create.stub
@@ -1,0 +1,29 @@
+<?php
+
+namespace {{livewireNamespace}}\{{modelNamePluralUpperCase}};
+
+use {{livewireNamespace}}\Forms\{{modelName}}Form;
+use {{modelNamespace}}\{{modelName}};
+use Livewire\Component;
+
+class Create extends Component
+{
+    public {{modelName}}Form $form;
+
+    public function mount({{modelName}} ${{modelNameLowerCase}})
+    {
+        $this->form->set{{modelName}}Model(${{modelNameLowerCase}});
+    }
+
+    public function save()
+    {
+        $this->form->store();
+
+        return $this->redirectRoute('{{modelRoute}}.index', navigate: true);
+    }
+
+    public function render()
+    {
+        return view('livewire.{{modelView}}.create');
+    }
+}

--- a/src/stubs/livewire/edit.stub
+++ b/src/stubs/livewire/edit.stub
@@ -1,0 +1,29 @@
+<?php
+
+namespace {{livewireNamespace}}\{{modelNamePluralUpperCase}};
+
+use {{livewireNamespace}}\Forms\{{modelName}}Form;
+use {{modelNamespace}}\{{modelName}};
+use Livewire\Component;
+
+class Edit extends Component
+{
+    public {{modelName}}Form $form;
+
+    public function mount({{modelName}} ${{modelNameLowerCase}})
+    {
+        $this->form->set{{modelName}}Model(${{modelNameLowerCase}});
+    }
+
+    public function save()
+    {
+        $this->form->update();
+
+        return $this->redirectRoute('{{modelRoute}}.index', navigate: true);
+    }
+
+    public function render()
+    {
+        return view('livewire.{{modelView}}.edit');
+    }
+}

--- a/src/stubs/livewire/form.stub
+++ b/src/stubs/livewire/form.stub
@@ -1,0 +1,38 @@
+<?php
+
+namespace {{livewireNamespace}}\Forms;
+
+use {{modelNamespace}}\{{modelName}};
+use Livewire\Form;
+
+class {{modelName}}Form extends Form
+{
+    public ?{{modelName}} ${{modelNameLowerCase}}Model;
+    {{livewireFormProperties}}
+
+    public function rules(): array
+    {
+        return [{{rules}}
+        ];
+    }
+
+    public function set{{modelName}}Model({{modelName}} ${{modelNameLowerCase}}Model): void
+    {
+        $this->{{modelNameLowerCase}}Model = ${{modelNameLowerCase}}Model;
+        {{livewireFormSetValues}}
+    }
+
+    public function store(): void
+    {
+        $this->{{modelNameLowerCase}}Model->create($this->validate());
+
+        $this->reset();
+    }
+
+    public function update(): void
+    {
+        $this->{{modelNameLowerCase}}Model->update($this->validate());
+
+        $this->reset();
+    }
+}

--- a/src/stubs/livewire/index.stub
+++ b/src/stubs/livewire/index.stub
@@ -1,0 +1,28 @@
+<?php
+
+namespace {{livewireNamespace}}\{{modelNamePluralUpperCase}};
+
+use {{modelNamespace}}\{{modelName}};
+use Illuminate\View\View;
+use Livewire\Component;
+use Livewire\WithPagination;
+
+class Index extends Component
+{
+    use WithPagination;
+
+    public function render(): View
+    {
+        ${{modelNamePluralLowerCase}} = {{modelName}}::paginate();
+
+        return view('livewire.{{modelView}}.index', compact('{{modelNamePluralLowerCase}}'))
+            ->with('i', $this->getPage() * ${{modelNamePluralLowerCase}}->perPage());
+    }
+
+    public function delete({{modelName}} ${{modelNameLowerCase}})
+    {
+        ${{modelNameLowerCase}}->delete();
+
+        return $this->redirectRoute('{{modelRoute}}.index', navigate: true);
+    }
+}

--- a/src/stubs/livewire/show.stub
+++ b/src/stubs/livewire/show.stub
@@ -1,0 +1,22 @@
+<?php
+
+namespace {{livewireNamespace}}\{{modelNamePluralUpperCase}};
+
+use {{livewireNamespace}}\Forms\{{modelName}}Form;
+use {{modelNamespace}}\{{modelName}};
+use Livewire\Component;
+
+class Show extends Component
+{
+    public {{modelName}}Form $form;
+
+    public function mount({{modelName}} ${{modelNameLowerCase}})
+    {
+        $this->form->set{{modelName}}Model(${{modelNameLowerCase}});
+    }
+
+    public function render()
+    {
+        return view('livewire.{{modelView}}.show', ['{{modelNameLowerCase}}' => $this->form->{{modelNameLowerCase}}Model]);
+    }
+}


### PR DESCRIPTION
The generator looks for lowercase stub files (index.stub, create.stub, etc.) but the files were named with uppercase first letters (Index.stub, Create.stub, etc.).
On Windows/macOS this works fine, but on Linux (case-sensitive FS) it throws FileNotFoundException.

Renamed stubs to lowercase so it works consistently across platforms.